### PR TITLE
feat: add N8N signal ingestion system for OpenClaw dashboard

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+# Copy to .env.local and fill in your values
+OPENCLAW_API_KEY=your_secret_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.next/
+node_modules/
+.env.local
+data/signals.json

--- a/app/api/signals/route.ts
+++ b/app/api/signals/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import { validateApiKey } from "@/lib/auth";
+import { saveSignal, getSignals } from "@/lib/storage";
+import type { Signal, Workflow } from "@/lib/types";
+
+// POST /api/signals
+export async function POST(req: NextRequest) {
+  if (!validateApiKey(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("workflow" in body) ||
+    !("timestamp" in body) ||
+    !("payload" in body)
+  ) {
+    return NextResponse.json(
+      { error: "Missing required fields: workflow, timestamp, payload" },
+      { status: 400 }
+    );
+  }
+
+  const { workflow, timestamp, payload } = body as {
+    workflow: string;
+    timestamp: string;
+    payload: unknown;
+  };
+
+  if (workflow !== "ev_detector" && workflow !== "steufy_intel") {
+    return NextResponse.json(
+      { error: "workflow must be 'ev_detector' or 'steufy_intel'" },
+      { status: 400 }
+    );
+  }
+
+  const signal: Signal = {
+    id: uuidv4(),
+    workflow: workflow as Workflow,
+    timestamp,
+    payload: payload as Signal["payload"],
+    received_at: new Date().toISOString(),
+  };
+
+  saveSignal(signal);
+
+  return NextResponse.json({ status: "ok", id: signal.id }, { status: 201 });
+}
+
+// GET /api/signals?workflow=ev_detector&limit=20
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const workflow = searchParams.get("workflow") as Workflow | null;
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 100);
+
+  if (
+    workflow &&
+    workflow !== "ev_detector" &&
+    workflow !== "steufy_intel"
+  ) {
+    return NextResponse.json(
+      { error: "Invalid workflow filter" },
+      { status: 400 }
+    );
+  }
+
+  const signals = getSignals(workflow ?? undefined, limit);
+  return NextResponse.json({ signals });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  background-color: #0a0a0f;
+  color: #f0f0f5;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "OpenClaw — Signal Dashboard",
+  description: "N8N signal ingestion dashboard",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className="dark">
+      <body className="min-h-screen bg-claw-bg font-mono antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import EVDetectorPanel from "@/components/EVDetectorPanel";
+import IntelPanel from "@/components/IntelPanel";
+import type { Signal } from "@/lib/types";
+
+const POLL_INTERVAL = 60_000; // 60s
+
+export default function DashboardPage() {
+  const [evSignals, setEvSignals] = useState<Signal[]>([]);
+  const [intelSignal, setIntelSignal] = useState<Signal | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchSignals = useCallback(async () => {
+    try {
+      const [evRes, intelRes] = await Promise.all([
+        fetch("/api/signals?workflow=ev_detector&limit=20"),
+        fetch("/api/signals?workflow=steufy_intel&limit=1"),
+      ]);
+
+      if (evRes.ok) {
+        const { signals } = await evRes.json();
+        setEvSignals(signals);
+      }
+      if (intelRes.ok) {
+        const { signals } = await intelRes.json();
+        setIntelSignal(signals[0] ?? null);
+      }
+      setLastRefresh(new Date());
+    } catch (err) {
+      console.error("Failed to fetch signals:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSignals();
+    const interval = setInterval(fetchSignals, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchSignals]);
+
+  return (
+    <div className="min-h-screen bg-claw-bg">
+      {/* Header */}
+      <header className="border-b border-claw-border bg-claw-surface/80 backdrop-blur sticky top-0 z-10">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
+          <div className="flex items-center gap-3">
+            <span className="text-lg font-bold tracking-tight text-white">
+              Open<span className="text-violet-400">Claw</span>
+            </span>
+            <span className="hidden sm:inline-block rounded-full border border-claw-border px-2 py-0.5 text-xs text-claw-muted">
+              Signal Dashboard
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            {loading && (
+              <span className="text-xs text-claw-muted animate-pulse">Loading…</span>
+            )}
+            {lastRefresh && !loading && (
+              <span className="text-xs text-claw-muted hidden sm:block">
+                Refreshed {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+            <button
+              onClick={fetchSignals}
+              className="rounded-lg border border-claw-border bg-claw-bg px-3 py-1.5 text-xs text-white/70 transition-colors hover:border-violet-500/50 hover:text-white"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main grid */}
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6">
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Left: EV+ Detector */}
+          <section>
+            <EVDetectorPanel signals={evSignals} />
+          </section>
+
+          {/* Right: Steufy Intel */}
+          <section>
+            <IntelPanel signal={intelSignal} />
+          </section>
+        </div>
+
+        {/* Footer note */}
+        <p className="mt-6 text-center text-xs text-claw-muted">
+          Auto-refresh every 60s &nbsp;·&nbsp; POST to{" "}
+          <code className="text-violet-400">/api/signals</code> with{" "}
+          <code className="text-violet-400">Authorization: Bearer &lt;OPENCLAW_API_KEY&gt;</code>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/components/EVDetectorPanel.tsx
+++ b/components/EVDetectorPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import type { Signal, EVDetectorPayload } from "@/lib/types";
+import { timeAgo, scoreBadgeClass } from "@/lib/utils";
+
+interface Props {
+  signals: Signal[];
+}
+
+export default function EVDetectorPanel({ signals }: Props) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (signals.length === 0) {
+    return (
+      <div className="rounded-xl border border-claw-border bg-claw-surface p-6">
+        <PanelHeader />
+        <p className="mt-6 text-center text-sm text-claw-muted">
+          No signals yet — waiting for EV+ Detector
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-claw-border bg-claw-surface">
+      <div className="border-b border-claw-border px-5 py-4">
+        <PanelHeader />
+      </div>
+      <ul className="divide-y divide-claw-border">
+        {signals.map((signal) => {
+          const p = signal.payload as EVDetectorPayload;
+          const isOpen = expanded === signal.id;
+          return (
+            <li key={signal.id}>
+              <button
+                onClick={() => setExpanded(isOpen ? null : signal.id)}
+                className="w-full px-5 py-3 text-left transition-colors hover:bg-white/[0.03]"
+              >
+                <div className="flex items-center gap-3 flex-wrap">
+                  {/* Score badge */}
+                  <span
+                    className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono font-semibold ${scoreBadgeClass(p.score)}`}
+                  >
+                    {p.score}/10
+                  </span>
+
+                  {/* Direction pill */}
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                      p.direction === "YES"
+                        ? "bg-emerald-500/15 text-emerald-400"
+                        : "bg-red-500/15 text-red-400"
+                    }`}
+                  >
+                    {p.direction}
+                  </span>
+
+                  {/* Event name */}
+                  <span className="flex-1 truncate text-sm text-white/90 font-medium">
+                    {p.event}
+                  </span>
+
+                  {/* Polymarket */}
+                  <span className="text-xs text-claw-muted font-mono">
+                    {(p.polymarket_prob * 100).toFixed(1)}%
+                  </span>
+
+                  {/* Timestamp */}
+                  <span className="text-xs text-claw-muted">
+                    {timeAgo(signal.timestamp)}
+                  </span>
+
+                  {/* Chevron */}
+                  <svg
+                    className={`h-4 w-4 text-claw-muted shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+
+                {/* Expanded resume */}
+                {isOpen && (
+                  <div className="mt-3 rounded-lg bg-black/30 px-4 py-3 text-left">
+                    <p className="text-sm leading-relaxed text-white/80">{p.resume}</p>
+                    <p className="mt-2 text-xs text-claw-muted font-mono">
+                      {new Date(signal.timestamp).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function PanelHeader() {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex h-2 w-2 rounded-full bg-violet-400" />
+      <h2 className="text-sm font-semibold text-white/90 tracking-wide uppercase">
+        EV+ Detector
+      </h2>
+    </div>
+  );
+}

--- a/components/IntelPanel.tsx
+++ b/components/IntelPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { Signal, IntelPayload } from "@/lib/types";
+import { timeAgo, changeClass, formatChange, formatPrice } from "@/lib/utils";
+
+interface Props {
+  signal: Signal | null;
+}
+
+export default function IntelPanel({ signal }: Props) {
+  if (!signal) {
+    return (
+      <div className="rounded-xl border border-claw-border bg-claw-surface p-6">
+        <PanelHeader lastUpdate={null} />
+        <p className="mt-6 text-center text-sm text-claw-muted">
+          No intel yet — waiting for Steufy Intel
+        </p>
+      </div>
+    );
+  }
+
+  const p = signal.payload as IntelPayload;
+  const tokens = Object.entries(p.prices) as [
+    string,
+    { price: number; change_24h: number }
+  ][];
+
+  return (
+    <div className="rounded-xl border border-claw-border bg-claw-surface">
+      <div className="border-b border-claw-border px-5 py-4">
+        <PanelHeader lastUpdate={signal.timestamp} />
+      </div>
+
+      {/* Price table */}
+      <div className="px-5 pt-4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-claw-muted">
+          Prices
+        </p>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-claw-border">
+              <th className="pb-2 text-left text-xs text-claw-muted font-normal">Token</th>
+              <th className="pb-2 text-right text-xs text-claw-muted font-normal">Price</th>
+              <th className="pb-2 text-right text-xs text-claw-muted font-normal">24h</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map(([token, data]) => (
+              <tr key={token} className="border-b border-claw-border/50 last:border-0">
+                <td className="py-2 font-mono font-semibold text-white/90">{token}</td>
+                <td className="py-2 text-right font-mono text-white/80">
+                  {formatPrice(data.price)}
+                </td>
+                <td className={`py-2 text-right font-mono font-medium ${changeClass(data.change_24h)}`}>
+                  {formatChange(data.change_24h)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Narratives */}
+      {p.narratives.length > 0 && (
+        <div className="px-5 pt-4">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-claw-muted">
+            Top Narratives
+          </p>
+          <ul className="space-y-1.5">
+            {p.narratives.map((n, i) => (
+              <li key={i} className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono text-sm font-semibold text-white/90">
+                  {n.token}
+                </span>
+                <span
+                  className={`text-xs font-mono font-medium ${changeClass(n.change_24h)}`}
+                >
+                  {formatChange(n.change_24h)}
+                </span>
+                <span className="rounded-full border border-claw-border bg-claw-bg px-2 py-0.5 text-xs text-claw-muted">
+                  {n.category}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Digest */}
+      <div className="px-5 pt-4">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-claw-muted">
+          Digest
+        </p>
+        <p className="text-sm leading-relaxed text-white/70">{p.digest}</p>
+      </div>
+
+      {/* Action */}
+      <div className="mx-5 my-4 rounded-lg border border-violet-500/30 bg-violet-500/10 px-4 py-3">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-violet-400">
+          Action
+        </p>
+        <p className="text-sm font-medium text-white/90">{p.action}</p>
+      </div>
+    </div>
+  );
+}
+
+function PanelHeader({ lastUpdate }: { lastUpdate: string | null }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2">
+        <span className="flex h-2 w-2 rounded-full bg-cyan-400" />
+        <h2 className="text-sm font-semibold text-white/90 tracking-wide uppercase">
+          Steufy Intel
+        </h2>
+      </div>
+      {lastUpdate && (
+        <span className="text-xs text-claw-muted">
+          Updated {timeAgo(lastUpdate)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+
+export function validateApiKey(req: NextRequest): boolean {
+  const apiKey = process.env.OPENCLAW_API_KEY;
+  if (!apiKey) return false;
+
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return false;
+
+  const provided = authHeader.slice(7);
+  return provided === apiKey;
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import path from "path";
+import type { Signal, SignalsStore, Workflow } from "./types";
+
+const DATA_DIR = path.join(process.cwd(), "data");
+const SIGNALS_FILE = path.join(DATA_DIR, "signals.json");
+const MAX_SIGNALS = 500;
+
+function ensureDataDir() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function readStore(): SignalsStore {
+  ensureDataDir();
+  if (!fs.existsSync(SIGNALS_FILE)) {
+    return { signals: [] };
+  }
+  try {
+    const raw = fs.readFileSync(SIGNALS_FILE, "utf-8");
+    return JSON.parse(raw) as SignalsStore;
+  } catch {
+    return { signals: [] };
+  }
+}
+
+function writeStore(store: SignalsStore) {
+  ensureDataDir();
+  fs.writeFileSync(SIGNALS_FILE, JSON.stringify(store, null, 2), "utf-8");
+}
+
+export function saveSignal(signal: Signal): void {
+  const store = readStore();
+  store.signals.unshift(signal);
+  // cap at MAX_SIGNALS to avoid unbounded growth
+  if (store.signals.length > MAX_SIGNALS) {
+    store.signals = store.signals.slice(0, MAX_SIGNALS);
+  }
+  writeStore(store);
+}
+
+export function getSignals(workflow?: Workflow, limit = 20): Signal[] {
+  const store = readStore();
+  let filtered = workflow
+    ? store.signals.filter((s) => s.workflow === workflow)
+    : store.signals;
+  // already stored newest-first, sort by timestamp DESC to be safe
+  filtered = filtered.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+  return filtered.slice(0, limit);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,32 @@
+export type Workflow = "ev_detector" | "steufy_intel";
+
+export interface EVDetectorPayload {
+  event: string;
+  score: number;
+  direction: "YES" | "NO";
+  resume: string;
+  polymarket_prob: number;
+}
+
+export interface IntelPayload {
+  prices: {
+    SOL: { price: number; change_24h: number };
+    HYPE: { price: number; change_24h: number };
+    BP: { price: number; change_24h: number };
+  };
+  narratives: Array<{ token: string; change_24h: number; category: string }>;
+  digest: string;
+  action: string;
+}
+
+export interface Signal {
+  id: string;
+  workflow: Workflow;
+  timestamp: string;
+  payload: EVDetectorPayload | IntelPayload;
+  received_at: string;
+}
+
+export interface SignalsStore {
+  signals: Signal[];
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,30 @@
+export function timeAgo(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function scoreBadgeClass(score: number): string {
+  if (score >= 6) return "bg-emerald-500/20 text-emerald-400 border-emerald-500/30";
+  if (score >= 4) return "bg-yellow-500/20 text-yellow-400 border-yellow-500/30";
+  return "bg-red-500/20 text-red-400 border-red-500/30";
+}
+
+export function changeClass(change: number): string {
+  return change >= 0 ? "text-emerald-400" : "text-red-400";
+}
+
+export function formatChange(change: number): string {
+  return `${change >= 0 ? "+" : ""}${change.toFixed(2)}%`;
+}
+
+export function formatPrice(price: number): string {
+  return price >= 1
+    ? `$${price.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `$${price.toFixed(6)}`;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "openclaw-signals",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "^18",
+    "react-dom": "^18",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@types/uuid": "^9",
+    "autoprefixer": "^10.0.1",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        claw: {
+          bg: "#0a0a0f",
+          surface: "#12121a",
+          border: "#1e1e2e",
+          accent: "#7c3aed",
+          "accent-dim": "#4c1d95",
+          muted: "#6b7280",
+        },
+      },
+      fontFamily: {
+        mono: ["JetBrains Mono", "Fira Code", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- POST /api/signals with Bearer auth (OPENCLAW_API_KEY)
- GET /api/signals?workflow=&limit= ordered by timestamp DESC
- Local JSON file storage (data/signals.json, capped at 500 entries)
- EVDetectorPanel: score badge (green/yellow/red), direction pill, timeAgo, expandable resume
- IntelPanel: price table SOL/HYPE/BP with 24h change, narratives, digest, action highlight
- Dashboard page with 60s auto-polling, responsive 2-col layout
- Supports ev_detector and steufy_intel payload shapes

https://claude.ai/code/session_011SFV7JmXukRpB9wZAtADWt