### PR TITLE
feat: Intel Digest — Octav + CoinGecko → Telegram 07:30/17:30

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ TELEGRAM_CHAT_ID=<your-telegram-chat-id>
 MAX_TRADE_SIZE_USD=100
 SLIPPAGE_TOLERANCE_PCT=0.5
 MIN_SPREAD_PCT=0.5
+
+# ── Intel Digest (portfolio tracker + market data) ──────────────────────────
+
+# Solana wallet address to track via Octav (public address, not private key)
+INTEL_WALLET_ADDRESS=<your-solana-public-address>
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc",
     "start": "node dist/main.js",
     "dev": "ts-node src/main.ts",
+    "intel": "ts-node src/intel-scheduler.ts",
+    "intel:build": "tsc && node dist/intel-scheduler.js",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"
   },

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -1,0 +1,132 @@
+import axios from "axios";
+import { OctavPortfolio, OctavPosition, filterPositions } from "./portfolio-octav";
+import { TokenMarketData, TopMover } from "./market-coingecko";
+
+const TELEGRAM_BASE = "https://api.telegram.org";
+
+// Fixed BP holdings (16,000 tokens as per spec)
+const BP_FIXED_AMOUNT = 16_000;
+
+function formatChange(pct: number): string {
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function formatPrice(usd: number): string {
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  if (usd >= 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(6)}`;
+}
+
+function buildDigestMessage(
+  portfolio: OctavPortfolio,
+  marketData: TokenMarketData[],
+  topMovers: TopMover[]
+): string {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    timeZone: "Europe/Paris",
+  });
+  const timeStr = now.toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/Paris",
+  });
+
+  // Portfolio section — from Octav
+  const targetSymbols = ["SOL", "HYPE", "BP"];
+  const octavPositions = filterPositions(portfolio, targetSymbols);
+  const marketBySymbol = Object.fromEntries(marketData.map((m) => [m.symbol, m]));
+
+  let portfolioLines = "";
+  for (const sym of targetSymbols) {
+    const pos = octavPositions.find((p) => p.symbol === sym);
+    const market = marketBySymbol[sym];
+
+    const price = market?.priceUsd ?? pos?.priceUsd ?? 0;
+    const change = market?.change24hPct ?? pos?.change24hPct ?? 0;
+    const changeStr = formatChange(change);
+    const priceStr = formatPrice(price);
+
+    if (sym === "BP") {
+      const value = (price * BP_FIXED_AMOUNT).toFixed(0);
+      portfolioLines += `• BP: ${priceStr} (${changeStr}) — ${BP_FIXED_AMOUNT.toLocaleString()} tokens ($${value})\n`;
+    } else if (pos) {
+      const holdingStr = `${pos.amount.toFixed(2)} ${sym}`;
+      portfolioLines += `• ${sym}: ${priceStr} (${changeStr}) — ${holdingStr}\n`;
+    } else {
+      portfolioLines += `• ${sym}: ${priceStr} (${changeStr})\n`;
+    }
+  }
+
+  // Top movers section
+  let moversLines = "";
+  for (const mover of topMovers) {
+    const arrow = mover.change24hPct >= 0 ? "🟢" : "🔴";
+    moversLines += `${arrow} ${mover.symbol}: ${formatPrice(mover.priceUsd)} (${formatChange(mover.change24hPct)})\n`;
+  }
+
+  // Claude analysis — simple rule-based signal
+  const solData = marketBySymbol["SOL"];
+  let action = "Pas de signal fort. Observer.";
+  if (solData) {
+    if (solData.change24hPct > 5) {
+      action = "SOL en forte hausse (+5%). Arbitrage actif, surveiller les spreads.";
+    } else if (solData.change24hPct < -5) {
+      action = "SOL en baisse (-5%). Réduire l'exposition, attendre stabilisation.";
+    } else if (solData.change24hPct > 2) {
+      action = "Momentum positif sur SOL. Bot arb en conditions favorables.";
+    }
+  }
+
+  const totalValue = portfolio.totalValueUsd > 0
+    ? `\n💼 Total portfolio: $${portfolio.totalValueUsd.toFixed(2)}\n`
+    : "";
+
+  return (
+    `📊 <b>CRYPTO INTEL — ${dateStr} ${timeStr}</b>\n\n` +
+    `💰 <b>PORTFOLIO (Octav):</b>\n${portfolioLines}${totalValue}\n` +
+    `🔥 <b>TOP MOVERS Solana:</b>\n${moversLines}\n` +
+    `🎯 <b>ACTION:</b> ${action}`
+  );
+}
+
+export async function sendDigest(
+  botToken: string,
+  chatId: string,
+  portfolio: OctavPortfolio,
+  marketData: TokenMarketData[],
+  topMovers: TopMover[]
+): Promise<void> {
+  const text = buildDigestMessage(portfolio, marketData, topMovers);
+
+  await axios.post(
+    `${TELEGRAM_BASE}/bot${botToken}/sendMessage`,
+    {
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+    },
+    { timeout: 10_000 }
+  );
+}
+
+/** Send a plain error alert to Telegram */
+export async function sendErrorAlert(
+  botToken: string,
+  chatId: string,
+  context: string,
+  err: Error
+): Promise<void> {
+  const text = `🔴 <b>Intel Digest — Erreur</b>\n\nContexte: ${context}\nErreur: ${err.message}`;
+  await axios
+    .post(
+      `${TELEGRAM_BASE}/bot${botToken}/sendMessage`,
+      { chat_id: chatId, text, parse_mode: "HTML" },
+      { timeout: 10_000 }
+    )
+    .catch(() => {}); // never crash on alert failure
+}

--- a/src/intel-scheduler.ts
+++ b/src/intel-scheduler.ts
@@ -1,0 +1,67 @@
+/**
+ * Intel Digest Scheduler
+ * Sends portfolio + market digest to Telegram at 07:30 and 17:30 Paris time.
+ *
+ * Run independently from the arb bot:
+ *   npx ts-node src/intel-scheduler.ts
+ *   node dist/intel-scheduler.js
+ */
+
+import * as cron from "node-cron";
+import * as dotenv from "dotenv";
+import { fetchOctavPortfolio } from "./portfolio-octav";
+import { fetchTokenPrices, fetchTopSolanaMovers } from "./market-coingecko";
+import { sendDigest, sendErrorAlert } from "./digest";
+
+dotenv.config();
+
+const WALLET = process.env["INTEL_WALLET_ADDRESS"] ?? "";
+const BOT_TOKEN = process.env["TELEGRAM_BOT_TOKEN"] ?? "";
+const CHAT_ID = process.env["TELEGRAM_CHAT_ID"] ?? "";
+const TARGET_SYMBOLS = ["SOL", "HYPE", "BP"];
+
+if (!WALLET || !BOT_TOKEN || !CHAT_ID) {
+  console.error(
+    "[Intel] Missing env vars: INTEL_WALLET_ADDRESS, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID"
+  );
+  process.exit(1);
+}
+
+async function runDigest(): Promise<void> {
+  console.log("[Intel] Running digest...");
+
+  const [portfolio, marketData, topMovers] = await Promise.all([
+    fetchOctavPortfolio(WALLET),
+    fetchTokenPrices(TARGET_SYMBOLS),
+    fetchTopSolanaMovers(5),
+  ]);
+
+  await sendDigest(BOT_TOKEN, CHAT_ID, portfolio, marketData, topMovers);
+  console.log("[Intel] Digest sent.");
+}
+
+async function safeRunDigest(): Promise<void> {
+  try {
+    await runDigest();
+  } catch (err) {
+    console.error("[Intel] Digest failed:", (err as Error).message);
+    await sendErrorAlert(BOT_TOKEN, CHAT_ID, "Intel Digest", err as Error);
+  }
+}
+
+// 07:30 Paris time (Europe/Paris = UTC+1 winter / UTC+2 summer)
+cron.schedule("30 7 * * *", () => void safeRunDigest(), {
+  timezone: "Europe/Paris",
+});
+
+// 17:30 Paris time
+cron.schedule("30 17 * * *", () => void safeRunDigest(), {
+  timezone: "Europe/Paris",
+});
+
+console.log("[Intel] Scheduler started — digest at 07:30 + 17:30 Europe/Paris");
+console.log("[Intel] Wallet:", WALLET);
+
+// Send one immediately on startup so you can validate it works
+console.log("[Intel] Sending startup digest...");
+void safeRunDigest();

--- a/src/market-coingecko.ts
+++ b/src/market-coingecko.ts
@@ -1,0 +1,97 @@
+import axios from "axios";
+
+const COINGECKO_BASE = "https://api.coingecko.com/api/v3";
+
+// CoinGecko IDs for target tokens
+export const COINGECKO_IDS: Record<string, string> = {
+  SOL: "solana",
+  HYPE: "hyperliquid",
+  BP: "backpack-exchange",
+};
+
+export interface TokenMarketData {
+  symbol: string;
+  coingeckoId: string;
+  priceUsd: number;
+  change24hPct: number;
+  marketCapUsd: number;
+  volume24hUsd: number;
+}
+
+export interface TopMover {
+  symbol: string;
+  priceUsd: number;
+  change24hPct: number;
+}
+
+interface CoinGeckoMarket {
+  id: string;
+  symbol: string;
+  current_price: number;
+  price_change_percentage_24h: number;
+  market_cap: number;
+  total_volume: number;
+}
+
+export async function fetchTokenPrices(
+  symbols: string[]
+): Promise<TokenMarketData[]> {
+  const ids = symbols
+    .map((s) => COINGECKO_IDS[s.toUpperCase()])
+    .filter(Boolean);
+
+  if (ids.length === 0) return [];
+
+  const res = await axios.get(`${COINGECKO_BASE}/coins/markets`, {
+    params: {
+      vs_currency: "usd",
+      ids: ids.join(","),
+      order: "market_cap_desc",
+      per_page: ids.length,
+      page: 1,
+      sparkline: false,
+      price_change_percentage: "24h",
+    },
+    timeout: 10_000,
+  });
+
+  const coins = res.data as CoinGeckoMarket[];
+
+  // Map back from CoinGecko ID to our symbol
+  const idToSymbol: Record<string, string> = {};
+  for (const [sym, id] of Object.entries(COINGECKO_IDS)) {
+    idToSymbol[id] = sym;
+  }
+
+  return coins.map((c) => ({
+    symbol: idToSymbol[c.id] ?? c.symbol.toUpperCase(),
+    coingeckoId: c.id,
+    priceUsd: c.current_price,
+    change24hPct: c.price_change_percentage_24h ?? 0,
+    marketCapUsd: c.market_cap,
+    volume24hUsd: c.total_volume,
+  }));
+}
+
+/** Fetch top movers in Solana ecosystem (by 24h gain) */
+export async function fetchTopSolanaMovers(limit: number = 5): Promise<TopMover[]> {
+  const res = await axios.get(`${COINGECKO_BASE}/coins/markets`, {
+    params: {
+      vs_currency: "usd",
+      category: "solana-ecosystem",
+      order: "price_change_percentage_24h_desc",
+      per_page: limit,
+      page: 1,
+      sparkline: false,
+    },
+    timeout: 10_000,
+  });
+
+  const coins = res.data as CoinGeckoMarket[];
+
+  return coins.map((c) => ({
+    symbol: c.symbol.toUpperCase(),
+    priceUsd: c.current_price,
+    change24hPct: c.price_change_percentage_24h ?? 0,
+  }));
+}

--- a/src/portfolio-octav.ts
+++ b/src/portfolio-octav.ts
@@ -1,0 +1,74 @@
+import axios from "axios";
+
+const OCTAV_BASE = "https://api.octav.fi";
+
+export interface OctavPosition {
+  symbol: string;
+  amount: number;
+  valueUsd: number;
+  priceUsd: number;
+  change24hPct: number | null;
+}
+
+export interface OctavPortfolio {
+  wallet: string;
+  totalValueUsd: number;
+  positions: OctavPosition[];
+  fetchedAt: string;
+}
+
+interface OctavRawToken {
+  symbol: string;
+  amount: number;
+  usdValue: number;
+  price: number;
+  priceChange24h?: number;
+}
+
+interface OctavRawResponse {
+  totalUsdValue?: number;
+  tokens?: OctavRawToken[];
+  // some versions use different field names
+  total_value_usd?: number;
+  positions?: OctavRawToken[];
+}
+
+export async function fetchOctavPortfolio(
+  walletAddress: string
+): Promise<OctavPortfolio> {
+  const res = await axios.get(
+    `${OCTAV_BASE}/api/v1/portfolios/${walletAddress}`,
+    {
+      headers: { "Content-Type": "application/json" },
+      timeout: 15_000,
+    }
+  );
+
+  const data = res.data as OctavRawResponse;
+  const rawPositions = data.tokens ?? data.positions ?? [];
+  const totalValueUsd = data.totalUsdValue ?? data.total_value_usd ?? 0;
+
+  const positions: OctavPosition[] = rawPositions.map((p) => ({
+    symbol: p.symbol.toUpperCase(),
+    amount: p.amount,
+    valueUsd: p.usdValue,
+    priceUsd: p.price,
+    change24hPct: p.priceChange24h ?? null,
+  }));
+
+  return {
+    wallet: walletAddress,
+    totalValueUsd,
+    positions,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+/** Filter to target symbols only */
+export function filterPositions(
+  portfolio: OctavPortfolio,
+  symbols: string[]
+): OctavPosition[] {
+  const upper = symbols.map((s) => s.toUpperCase());
+  return portfolio.positions.filter((p) => upper.includes(p.symbol));
+}


### PR DESCRIPTION
## Modules ajoutés

| Fichier | Rôle |
|---|---|
| `src/portfolio-octav.ts` | Fetch portfolio Solana via Octav API |
| `src/market-coingecko.ts` | Prix + 24h change SOL/HYPE/BP + top 5 movers Solana |
| `src/digest.ts` | Formate et envoie le message Telegram HTML |
| `src/intel-scheduler.ts` | Cron 07:30 + 17:30 Europe/Paris, envoie un digest au démarrage |

## Config requise dans `.env`

```
INTEL_WALLET_ADDRESS=QBAz9HXmo7xuEFcecMKY92K2bS9ou7vUk1oVEymWyNG
TELEGRAM_BOT_TOKEN=<ton-token>
TELEGRAM_CHAT_ID=307358521
```

## Lancement

```bash
# Dev
npm run intel

# Prod (PM2)
npm run build
pm2 start dist/intel-scheduler.js --name intel-digest
```

## Format du message Telegram

```
📊 CRYPTO INTEL — lundi 7 avril 07:30

💰 PORTFOLIO (Octav):
• SOL: $142.30 (+3.2%) — 12.50 SOL
• HYPE: $18.45 (-1.1%)
• BP: $0.0234 (+5.4%) — 16,000 tokens ($374)

🔥 TOP MOVERS Solana:
🟢 JTO: $3.21 (+12.4%)
🟢 BONK: $0.000031 (+8.1%)
...

🎯 ACTION: Momentum positif sur SOL. Bot arb en conditions favorables.
```

https://claude.ai/code/session_012tiWmHApojCVRNuH9cK3EL