### PR TITLE
feat: Raydium DEX integration — CLMM pricing + direct swap routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@raydium-io/raydium-sdk-v2": "^0.2.39-alpha",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
         "axios": "^1.14.0",
@@ -1366,6 +1367,27 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@raydium-io/raydium-sdk-v2": {
+      "version": "0.2.39-alpha",
+      "resolved": "https://registry.npmjs.org/@raydium-io/raydium-sdk-v2/-/raydium-sdk-v2-0.2.39-alpha.tgz",
+      "integrity": "sha512-MSEwcUTZCFIQPRWyMSdtc4XXjZAnMCeSID8UGBKzXS38OPWHyUxEE2ha3AOAVUC76m4RTtnaeXLU/iLb+IzFdg==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/spl-token": "^0.4.8",
+        "@solana/web3.js": "^1.95.3",
+        "axios": "^1.1.3",
+        "big.js": "^6.2.1",
+        "bn.js": "^5.2.1",
+        "bs58": "^6.0.0",
+        "dayjs": "^1.11.5",
+        "decimal.js-light": "^2.5.1",
+        "jsonfile": "^6.1.0",
+        "lodash": "^4.17.21",
+        "toformat": "^2.0.0",
+        "tsconfig-paths": "^4.2.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -2485,6 +2507,19 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
@@ -3001,6 +3036,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3018,6 +3059,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3637,7 +3684,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -5204,13 +5251,24 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/leven": {
@@ -5242,6 +5300,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -6451,6 +6515,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/toformat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz",
+      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==",
+      "license": "MIT"
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6567,6 +6637,29 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6640,6 +6733,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "@raydium-io/raydium-sdk-v2": "^0.2.39-alpha",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "axios": "^1.14.0",

--- a/src/dex-monitor.ts
+++ b/src/dex-monitor.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import { DexPrice, PriceData } from "./types";
 import { TOKEN_MINTS, DECIMALS } from "./token-registry";
+import { fetchRaydiumClmmPrice } from "./raydium-client";
 
 const JUPITER_BASE_URL = "https://quote-api.jup.ag/v6";
 const ORCA_BASE_URL = "https://api.mainnet.orca.so";
@@ -87,16 +88,25 @@ export async function fetchOrcaPrice(
   }
 }
 
+/**
+ * Fetch Raydium price directly from CLMM pool state.
+ * Falls back to the price-list API if no pool is registered for the pair.
+ */
 export async function fetchRaydiumPrice(
   inputMint: string,
-  outputMint: string
+  outputMint: string,
+  pair: string
 ): Promise<DexPrice | null> {
+  // Primary: CLMM pool (accurate, includes real fee rate + liquidity)
+  const clmm = await fetchRaydiumClmmPrice(pair);
+  if (clmm) return clmm;
+
+  // Fallback: price-list API (less accurate, no liquidity data)
   try {
-    const res = await http.get("https://price.raydium.io/list");
-    // Fix #7: validate response shape
-    const prices = res.data?.data;
+    const res = await http.get("https://api.raydium.io/v2/main/price");
+    const prices = res.data?.data ?? res.data;
     if (!prices || typeof prices !== "object") {
-      console.warn("[DEX Monitor] Raydium: unexpected response shape");
+      console.warn("[DEX Monitor] Raydium fallback: unexpected response shape");
       return null;
     }
 
@@ -109,10 +119,10 @@ export async function fetchRaydiumPrice(
       dex: "raydium",
       price: outputPrice / inputPrice,
       liquidity: 0,
-      fee: 0.0025,
+      fee: 0.0025, // standard AMM fee
     };
   } catch (err) {
-    console.error("[DEX Monitor] Raydium fetch failed:", (err as Error).message);
+    console.error("[DEX Monitor] Raydium fallback fetch failed:", (err as Error).message);
     return null;
   }
 }
@@ -139,7 +149,7 @@ export async function fetchPrices(
     ORCA_POOLS[pair]
       ? fetchOrcaPrice(ORCA_POOLS[pair])
       : Promise.resolve(null),
-    fetchRaydiumPrice(inputMint, outputMint),
+    fetchRaydiumPrice(inputMint, outputMint, pair),
   ]);
 
   const prices: Record<string, DexPrice> = {};

--- a/src/raydium-client.ts
+++ b/src/raydium-client.ts
@@ -1,0 +1,296 @@
+/**
+ * Raydium DEX Client
+ *
+ * Provides two capabilities:
+ * 1. Real-time price fetching from Raydium CLMM pools (replaces the basic price-list API)
+ * 2. Direct swap execution via Raydium's transaction API (parallel route alongside Jupiter)
+ *
+ * APIs used:
+ *   Pool data:  https://api.raydium.io/v2/ammV3/ammPools
+ *   Swap quote: https://transaction-v1.raydium.io/compute/swap-base-in
+ *   Swap tx:    https://transaction-v1.raydium.io/transaction/swap-base-in
+ */
+
+import axios from "axios";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { TOKEN_MINTS, DECIMALS } from "./token-registry";
+import { DexPrice } from "./types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RAYDIUM_API = "https://api.raydium.io/v2";
+const RAYDIUM_TX_API = "https://transaction-v1.raydium.io";
+const TIMEOUT_MS = 10_000;
+const CONFIRM_TIMEOUT_MS = 60_000;
+
+/**
+ * Known Raydium CLMM pool IDs for common pairs.
+ * Source: https://raydium.io/clmm/pools/
+ */
+export const RAYDIUM_POOLS: Record<string, string> = {
+  "SOL/USDC": "2QdhepnKRTLjjSqPL1PtKNwqrUkoLee5Gqs8bvZhRdMv",
+  "SOL/USDT": "HkG7fJJSNgKkBXmPbVqXZ8GQnk2YLJthrHHB2kFZMiMU",
+};
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RaydiumPoolData {
+  id: string;
+  price: number;
+  tvl: number;
+  feeRate: number; // raw fee rate (e.g. 2500 = 0.25%)
+}
+
+interface RaydiumSwapQuote {
+  inputMint: string;
+  outputMint: string;
+  inputAmount: string;
+  outputAmount: string;
+  priceImpactPct: number;
+  feeAmount: string;
+  poolId: string;
+}
+
+interface RaydiumSwapQuoteResponse {
+  id: string;
+  success: boolean;
+  data: RaydiumSwapQuote;
+}
+
+interface RaydiumSwapTxResponse {
+  id: string;
+  success: boolean;
+  data: {
+    transaction: string; // base64 VersionedTransaction
+  };
+}
+
+// ─── Price Fetching ───────────────────────────────────────────────────────────
+
+/**
+ * Fetch live price from a Raydium CLMM pool.
+ * Returns null on any fetch/parse error so the monitor loop continues gracefully.
+ */
+export async function fetchRaydiumClmmPrice(
+  pair: string
+): Promise<DexPrice | null> {
+  const poolId = RAYDIUM_POOLS[pair];
+  if (!poolId) return null;
+
+  try {
+    const res = await axios.get(`${RAYDIUM_API}/ammV3/ammPools`, {
+      params: { poolId },
+      timeout: TIMEOUT_MS,
+    });
+
+    const pools: RaydiumPoolData[] = res.data?.data ?? [];
+    const pool = pools.find((p) => p.id === poolId);
+
+    if (!pool || typeof pool.price !== "number" || pool.price <= 0) {
+      console.warn(
+        `[Raydium] Pool ${poolId} not found or invalid price:`,
+        pool
+      );
+      return null;
+    }
+
+    // feeRate is in hundredths of a bip (e.g. 2500 → 0.25%)
+    const feeDecimal = pool.feeRate / 1_000_000;
+
+    return {
+      dex: "raydium",
+      price: pool.price,
+      liquidity: pool.tvl ?? 0,
+      fee: feeDecimal,
+    };
+  } catch (err) {
+    console.error(
+      "[Raydium] CLMM price fetch failed:",
+      (err as Error).message
+    );
+    return null;
+  }
+}
+
+// ─── Swap Quote ───────────────────────────────────────────────────────────────
+
+function validateSwapQuote(raw: unknown): raw is RaydiumSwapQuoteResponse {
+  if (!raw || typeof raw !== "object") return false;
+  const r = raw as Record<string, unknown>;
+  if (!r["success"]) return false;
+  const d = r["data"] as Record<string, unknown> | undefined;
+  return (
+    !!d &&
+    typeof d["outputAmount"] === "string" &&
+    Number(d["outputAmount"]) > 0
+  );
+}
+
+export async function getRaydiumSwapQuote(
+  inputMint: string,
+  outputMint: string,
+  amountLamports: bigint,
+  slippageBps: number,
+  pair: string
+): Promise<RaydiumSwapQuote | null> {
+  const poolId = RAYDIUM_POOLS[pair];
+  if (!poolId) return null;
+
+  try {
+    const res = await axios.get(
+      `${RAYDIUM_TX_API}/compute/swap-base-in`,
+      {
+        params: {
+          inputMint,
+          outputMint,
+          amount: amountLamports.toString(),
+          slippageBps,
+          txVersion: "V0",
+        },
+        timeout: TIMEOUT_MS,
+      }
+    );
+
+    if (!validateSwapQuote(res.data)) {
+      console.warn("[Raydium] Invalid swap quote response:", res.data);
+      return null;
+    }
+
+    return (res.data as RaydiumSwapQuoteResponse).data;
+  } catch (err) {
+    console.error("[Raydium] Swap quote failed:", (err as Error).message);
+    return null;
+  }
+}
+
+// ─── Swap Execution ───────────────────────────────────────────────────────────
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function buildRaydiumSwapTx(
+  quote: RaydiumSwapQuote,
+  walletPublicKey: string,
+  priorityFeePerCu: number = 10_000
+): Promise<string> {
+  const res = await axios.post(
+    `${RAYDIUM_TX_API}/transaction/swap-base-in`,
+    {
+      computeUnitPriceMicroLamports: String(priorityFeePerCu),
+      swapResponse: quote,
+      txVersion: "V0",
+      wallet: walletPublicKey,
+      wrapSol: true,
+      unwrapSol: true,
+    },
+    { timeout: TIMEOUT_MS }
+  );
+
+  const txData = res.data as RaydiumSwapTxResponse;
+  if (!txData.success || !txData.data?.transaction) {
+    throw new Error(
+      `Raydium swap tx build failed: ${JSON.stringify(res.data)}`
+    );
+  }
+
+  return txData.data.transaction;
+}
+
+/**
+ * Execute a direct Raydium swap with retry + bounded confirmation.
+ * Returns the transaction signature on success.
+ */
+export async function executeRaydiumSwap(
+  connection: Connection,
+  wallet: Keypair,
+  inputMint: string,
+  outputMint: string,
+  amountLamports: bigint,
+  slippageBps: number,
+  pair: string,
+  retries: number = 3
+): Promise<string> {
+  const quote = await getRaydiumSwapQuote(
+    inputMint,
+    outputMint,
+    amountLamports,
+    slippageBps,
+    pair
+  );
+
+  if (!quote) {
+    throw new Error(
+      `[Raydium] No quote available for ${pair} (pool not registered or API down)`
+    );
+  }
+
+  const txBase64 = await buildRaydiumSwapTx(
+    quote,
+    wallet.publicKey.toString()
+  );
+
+  const tx = VersionedTransaction.deserialize(
+    Buffer.from(txBase64, "base64")
+  );
+  tx.sign([wallet]);
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const sig = await connection.sendTransaction(tx, {
+        maxRetries: 2,
+        skipPreflight: false,
+      });
+
+      const latestBlockhash = await connection.getLatestBlockhash("confirmed");
+      const result = await Promise.race([
+        connection.confirmTransaction(
+          { signature: sig, ...latestBlockhash },
+          "confirmed"
+        ),
+        sleep(CONFIRM_TIMEOUT_MS).then(() => {
+          throw new Error(
+            `Raydium confirmation timeout after ${CONFIRM_TIMEOUT_MS / 1000}s`
+          );
+        }),
+      ]);
+
+      if (result.value.err) {
+        throw new Error(
+          `Raydium tx error: ${JSON.stringify(result.value.err)}`
+        );
+      }
+
+      return sig;
+    } catch (err) {
+      if (attempt === retries) throw err;
+      const backoff = 2 ** attempt * 500;
+      console.warn(
+        `[Raydium] Attempt ${attempt} failed, retrying in ${backoff}ms: ${(err as Error).message}`
+      );
+      await sleep(backoff);
+    }
+  }
+
+  throw new Error("[Raydium] All retry attempts exhausted");
+}
+
+// ─── Utility ──────────────────────────────────────────────────────────────────
+
+/**
+ * Estimate effective output amount including Raydium fees.
+ * Useful for profitability comparison before committing a trade leg to Raydium vs Jupiter.
+ */
+export function estimateRaydiumOutput(
+  inputAmount: number,
+  price: number,
+  feeDecimal: number
+): number {
+  const grossOut = inputAmount * price;
+  return grossOut * (1 - feeDecimal);
+}

--- a/src/trade-executor.ts
+++ b/src/trade-executor.ts
@@ -9,6 +9,7 @@ import bs58 from "bs58";
 import { v4 as uuidv4 } from "uuid";
 import { ArbitrageOpportunity, TradeResult } from "./types";
 import { TOKEN_MINTS, DECIMALS } from "./token-registry";
+import { executeRaydiumSwap, getRaydiumSwapQuote } from "./raydium-client";
 
 const JUPITER_BASE_URL = "https://quote-api.jup.ag/v6";
 const MIN_SOL_FOR_FEES = 0.05;
@@ -185,66 +186,83 @@ export async function executeArbitrage(
   let sellTxHash: string | null = null;
 
   try {
-    // --- LEG 1: Buy (USDC → SOL) ---
-    const buyQuote = await getJupiterQuote(
-      inputMint,
-      midMint,
-      amountInLamports,
-      slippageBps
-    );
-    const buySwapTxBase64 = await buildJupiterSwapTx(
-      buyQuote,
-      wallet.publicKey.toString()
-    );
-    const buyTx = VersionedTransaction.deserialize(
-      Buffer.from(buySwapTxBase64, "base64")
-    );
-    buyTx.sign([wallet]);
-
+    // ─── LEG 1: Buy (USDC → SOL) ────────────────────────────────────────────
     console.log(`[Trade Executor] Sending buy leg on ${opportunity.buy_dex}...`);
-    buyTxHash = await sendWithRetry(connection, buyTx);
+
+    let solReceived: bigint;
+    let buyFeeUsd = 0;
+
+    if (opportunity.buy_dex === "raydium") {
+      // Route directly through Raydium CLMM — no Jupiter aggregation overhead
+      const raydiumQuote = await getRaydiumSwapQuote(
+        inputMint,
+        midMint,
+        amountInLamports,
+        slippageBps,
+        opportunity.pair
+      );
+      if (!raydiumQuote) {
+        return failed(`Raydium buy quote unavailable for ${opportunity.pair}`);
+      }
+      buyTxHash = await executeRaydiumSwap(
+        connection, wallet, inputMint, midMint,
+        amountInLamports, slippageBps, opportunity.pair
+      );
+      solReceived = BigInt(raydiumQuote.outputAmount);
+      buyFeeUsd = Number(raydiumQuote.feeAmount) / 10 ** quoteDecimals;
+    } else {
+      // Default: Jupiter (routes across all DEXs including Raydium, Orca, etc.)
+      const buyQuote = await getJupiterQuote(inputMint, midMint, amountInLamports, slippageBps);
+      const buySwapTxBase64 = await buildJupiterSwapTx(buyQuote, wallet.publicKey.toString());
+      const buyTx = VersionedTransaction.deserialize(Buffer.from(buySwapTxBase64, "base64"));
+      buyTx.sign([wallet]);
+      buyTxHash = await sendWithRetry(connection, buyTx);
+      solReceived = BigInt(buyQuote.outAmount);
+      buyFeeUsd =
+        (buyQuote.routePlan ?? []).reduce((acc, r) => acc + (r.swapInfo?.feeAmount ?? 0), 0) /
+        10 ** quoteDecimals;
+    }
+
     console.log(`[Trade Executor] Buy leg confirmed: ${buyTxHash}`);
 
-    // Fix #3: outAmount already validated — safe to parse
-    const solReceived = BigInt(buyQuote.outAmount);
-
-    // --- LEG 2: Sell (SOL → USDC) ---
-    const sellQuote = await getJupiterQuote(
-      midMint,
-      outputMint,
-      solReceived,
-      slippageBps
-    );
-    const sellSwapTxBase64 = await buildJupiterSwapTx(
-      sellQuote,
-      wallet.publicKey.toString()
-    );
-    const sellTx = VersionedTransaction.deserialize(
-      Buffer.from(sellSwapTxBase64, "base64")
-    );
-    sellTx.sign([wallet]);
-
+    // ─── LEG 2: Sell (SOL → USDC) ───────────────────────────────────────────
     console.log(`[Trade Executor] Sending sell leg on ${opportunity.sell_dex}...`);
-    sellTxHash = await sendWithRetry(connection, sellTx);
+
+    let usdcReceived: number;
+    let sellFeeUsd = 0;
+
+    if (opportunity.sell_dex === "raydium") {
+      const raydiumQuote = await getRaydiumSwapQuote(
+        midMint,
+        outputMint,
+        solReceived,
+        slippageBps,
+        opportunity.pair
+      );
+      if (!raydiumQuote) {
+        // Buy already executed — this is a partial trade
+        throw new Error(`Raydium sell quote unavailable for ${opportunity.pair} after buy executed`);
+      }
+      sellTxHash = await executeRaydiumSwap(
+        connection, wallet, midMint, outputMint,
+        solReceived, slippageBps, opportunity.pair
+      );
+      usdcReceived = Number(raydiumQuote.outputAmount) / 10 ** quoteDecimals;
+      sellFeeUsd = Number(raydiumQuote.feeAmount) / 10 ** quoteDecimals;
+    } else {
+      const sellQuote = await getJupiterQuote(midMint, outputMint, solReceived, slippageBps);
+      const sellSwapTxBase64 = await buildJupiterSwapTx(sellQuote, wallet.publicKey.toString());
+      const sellTx = VersionedTransaction.deserialize(Buffer.from(sellSwapTxBase64, "base64"));
+      sellTx.sign([wallet]);
+      sellTxHash = await sendWithRetry(connection, sellTx);
+      usdcReceived = Number(BigInt(sellQuote.outAmount)) / 10 ** quoteDecimals;
+      sellFeeUsd =
+        (sellQuote.routePlan ?? []).reduce((acc, r) => acc + (r.swapInfo?.feeAmount ?? 0), 0) /
+        10 ** quoteDecimals;
+    }
+
     console.log(`[Trade Executor] Sell leg confirmed: ${sellTxHash}`);
 
-    // Fix #8: P&L calculated from actual on-chain amounts, not estimates
-    const usdcReceived =
-      Number(BigInt(sellQuote.outAmount)) / 10 ** quoteDecimals;
-
-    // Fees from actual route data (fix #8 — not hardcoded)
-    const buyFeeUsd =
-      (buyQuote.routePlan ?? []).reduce(
-        (acc, r) => acc + (r.swapInfo?.feeAmount ?? 0),
-        0
-      ) /
-      10 ** quoteDecimals;
-    const sellFeeUsd =
-      (sellQuote.routePlan ?? []).reduce(
-        (acc, r) => acc + (r.swapInfo?.feeAmount ?? 0),
-        0
-      ) /
-      10 ** quoteDecimals;
     const totalFeesUsd = buyFeeUsd + sellFeeUsd;
 
     const profitUsd = usdcReceived - tradeSizeUsd;

--- a/tests/raydium-client.test.ts
+++ b/tests/raydium-client.test.ts
@@ -1,0 +1,48 @@
+import { estimateRaydiumOutput, RAYDIUM_POOLS } from "../src/raydium-client";
+
+describe("Raydium Client", () => {
+  describe("RAYDIUM_POOLS registry", () => {
+    it("has SOL/USDC pool registered", () => {
+      expect(RAYDIUM_POOLS["SOL/USDC"]).toBeDefined();
+      expect(typeof RAYDIUM_POOLS["SOL/USDC"]).toBe("string");
+      expect(RAYDIUM_POOLS["SOL/USDC"].length).toBeGreaterThan(20);
+    });
+
+    it("all pool IDs are non-empty strings", () => {
+      for (const [pair, id] of Object.entries(RAYDIUM_POOLS)) {
+        expect(typeof id).toBe("string");
+        expect(id.length).toBeGreaterThan(20);
+      }
+    });
+  });
+
+  describe("estimateRaydiumOutput", () => {
+    it("deducts fee from gross output", () => {
+      // 100 USDC → SOL at price 0.01 SOL/USDC, 0.25% fee
+      const out = estimateRaydiumOutput(100, 0.01, 0.0025);
+      const gross = 100 * 0.01; // 1 SOL
+      expect(out).toBeLessThan(gross);
+      expect(out).toBeCloseTo(gross * (1 - 0.0025), 5);
+    });
+
+    it("returns 0 for 0 input", () => {
+      expect(estimateRaydiumOutput(0, 100, 0.0025)).toBe(0);
+    });
+
+    it("returns gross output when fee is 0", () => {
+      const gross = 100 * 79.5;
+      expect(estimateRaydiumOutput(100, 79.5, 0)).toBeCloseTo(gross, 5);
+    });
+
+    it("handles high fee rates correctly", () => {
+      // 1% fee
+      const out = estimateRaydiumOutput(1000, 1, 0.01);
+      expect(out).toBeCloseTo(990, 1);
+    });
+
+    it("never returns a negative value for valid inputs", () => {
+      const out = estimateRaydiumOutput(100, 50, 0.9999);
+      expect(out).toBeGreaterThanOrEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
## Ce qui change

### `src/raydium-client.ts` (nouveau)

| Fonction | Rôle |
|---|---|
| `fetchRaydiumClmmPrice()` | Prix live depuis l'état du pool CLMM Raydium (TVL + fee rate réel) |
| `getRaydiumSwapQuote()` | Quote de swap via `transaction-v1.raydium.io` avec validation de réponse |
| `executeRaydiumSwap()` | Exécution directe avec retry + confirmation bornée à 60s |
| `estimateRaydiumOutput()` | Estimation pré-trade (input × price × (1 - fee)) |
| `RAYDIUM_POOLS` | Registry des pools CLMM connus (SOL/USDC, SOL/USDT) |

### `src/dex-monitor.ts`
- `fetchRaydiumPrice()` interroge d'abord le pool CLMM (prix précis + liquidité réelle)
- Fallback sur l'API price-list si le pool n'est pas enregistré

### `src/trade-executor.ts`
- Chaque leg est routé vers son DEX cible :
  - `buy_dex` / `sell_dex` === `"raydium"` → swap direct Raydium CLMM
  - Sinon → Jupiter (comportement existant)
- Fees calculés depuis `quote.feeAmount` Raydium (pas hardcodés)

## Tests
- 7 nouveaux tests dans `tests/raydium-client.test.ts`
- **21 tests au total, tous passent**

## Flux d'arbitrage mis à jour

```
Opportunité: raydium (buy) → orca (sell)

Leg 1: USDC → SOL via Raydium CLMM directement
         ↓ getRaydiumSwapQuote() + executeRaydiumSwap()
Leg 2: SOL → USDC via Jupiter (route vers Orca)
         ↓ getJupiterQuote() + buildJupiterSwapTx()
```

https://claude.ai/code/session_012tiWmHApojCVRNuH9cK3EL